### PR TITLE
use argparse to process command line arguments

### DIFF
--- a/wPGSA.py
+++ b/wPGSA.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # coding: UTF-8
 
+import argparse
 import sys, math, numpy
 import scipy as sp
 from scipy import stats
@@ -156,14 +157,20 @@ def write_result(result,TF_list,tp_list,experiment,output):
 				fo.write('\n')
 
 def start():
-	argvs = sys.argv
-	logFC_file = argvs[1]
-	network_file = argvs[2]
-	exp_value, tp_list = read_logFC(logFC_file)
-	positive, experiment = read_network(network_file)
-	result,TF_list = wPGSA(tp_list,exp_value,positive,experiment)
-	output = argvs[1].replace('.txt','')
-	write_result(result,TF_list,tp_list,experiment,output)
+    argparser = argparse.ArgumentParser(description='Estimates relative activities of transcriptional regulators from given transcriptome data.')
+    argparser.add_argument('--network-file', nargs=1, dest='network_file', metavar='network_file', help='network file used as a reference, shared in /network directory')
+    argparser.add_argument('--logfc-file', nargs=1, dest='logfc_file', metavar='logFC_file', help='gene expression data file with the values in the Log2 fold-change, example in /sample_logFC_file')
+
+    args = argparser.parse_args()
+    logFC_file = args.logfc_file[0]
+    network_file = args.network_file[0]
+
+    exp_value, tp_list = read_logFC(logFC_file)
+    positive, experiment = read_network(network_file)
+    result,TF_list = wPGSA(tp_list,exp_value,positive,experiment)
+
+    output = logFC_file.replace('.txt','')
+    write_result(result,TF_list,tp_list,experiment,output)
 
 if __name__ == "__main__":
 	try:


### PR DESCRIPTION
コマンドラインで実行するときに引数で渡すファイルの順序がばらばらでもいいようにキーワード引数にしました。(docker化するときに順序が変えられず困ったので)

`$ python wPGSA --help`

と実行すると引数のヘルプが見られるようになってます。

```
usage: wPGSA.py [-h] [--network-file network_file] [--logfc-file logFC_file]

Estimates relative activities of transcriptional regulators from given
transcriptome data.

optional arguments:
  -h, --help            show this help message and exit
  --network-file network_file
                        network file used as a reference, shared in /network
                        directory
  --logfc-file logFC_file
                        gene expression data file with the values in the Log2
                        fold-change, example in /sample_logFC_file
```

こんな感じです。
もしよければマージしてください！

（引数がなしで実行したときにもちゃんとメッセージ出すように実装しなければいけないけど後回しということで…）
